### PR TITLE
Fix double-report of fence regression during Parked→Active transition

### DIFF
--- a/crates/gossip-contracts/src/sim/invariants.rs
+++ b/crates/gossip-contracts/src/sim/invariants.rs
@@ -1015,8 +1015,8 @@ mod tests {
         );
     }
 
-    /// Parked→Active fires both S2 and S3 when using <=.
-    /// This verifies the reviewer's claim about overlapping violation detection.
+    /// A fence regression during Parked→Active (epoch 5→3) must fire only S2
+    /// (FenceMonotonicity), not the S3 sub-property (UnparkWithoutFenceBump).
     #[test]
     fn fence_regression_during_unpark_does_not_double_report() {
         let run = RunId::from_raw(1);


### PR DESCRIPTION
## Summary

Fixes a bug where a fence epoch regression during a `Parked→Active` unpark was reported as both S2 (`FenceMonotonicity`) and S3 (`UnparkWithoutFenceBump`). The S3 sub-property check used `<=` when it should have used `==`, causing it to overlap with S2's responsibility for detecting regressions.

## What Changed

- **`check_terminal_irreversibility`**: Changed `current_epoch <= old_epoch` to `current_epoch == old_epoch` so the `UnparkWithoutFenceBump` violation only fires when the epoch is unchanged (the actual "no bump" case). Fence regressions (current < old) are already caught by `check_fence_monotonicity` (S2).
- **New test**: `fence_regression_during_unpark_does_not_double_report` — verifies that a Parked(epoch=5)→Active(epoch=3) transition fires exactly one S2 violation and zero S3 violations.

## Why

Double-reporting the same underlying issue (fence regression) as two different violations muddies simulation diagnostics. Each invariant should have a non-overlapping detection domain.

## Test Plan

- [x] New test covers the exact double-report scenario
- [x] All 17 existing invariant tests continue to pass
- [x] `cargo clippy` and `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)