### PR TITLE
Fix Kani CI timeout in from_vec_inline_is_sound proof

### DIFF
--- a/crates/gossip-stdx/src/inline_vec.rs
+++ b/crates/gossip-stdx/src/inline_vec.rs
@@ -645,23 +645,29 @@ mod kani_proofs {
 
     // Verifies that `From<Vec>` writes each element within the inline
     // buffer and preserves element values after the move.
+    //
+    // Uses concrete symbolic values and a plain array snapshot to keep
+    // the SAT problem tractable (avoids Vec clone and push-loop
+    // allocation machinery that caused CI timeouts).
     #[kani::proof]
     #[kani::unwind(6)]
     fn from_vec_inline_is_sound() {
         const CAP: usize = 4;
+        let a: u32 = kani::any();
+        let b: u32 = kani::any();
+        let c: u32 = kani::any();
+        let d: u32 = kani::any();
+        let snapshot = [a, b, c, d];
+
         let len: usize = kani::any();
         kani::assume(len <= CAP);
-        let mut vec = Vec::with_capacity(len);
-        for _ in 0..len {
-            vec.push(kani::any::<u32>());
-        }
-        let snapshot: Vec<u32> = vec.clone();
+
+        let vec: Vec<u32> = snapshot[..len].to_vec();
         let v: InlineVec<u32, CAP> = vec.into();
+
         assert_eq!(v.len(), len);
         assert!(matches!(&v.repr, Repr::Inline { .. }));
-        for i in 0..len {
-            assert_eq!(v.as_slice()[i], snapshot[i]);
-        }
+        assert_eq!(v.as_slice(), &snapshot[..len]);
     }
 
     // Verifies that `uninit_array` produces a valid array for both


### PR DESCRIPTION
## Summary

Fix Kani CI timeout in `from_vec_inline_is_sound` proof by reducing SAT
solver complexity. The proof was not failing logically — the GitHub Actions
runner was killed after ~50s of SAT solving because Vec's internal
allocation machinery (grow_amortized, finish_grow, RawVecInner) created
too many verification conditions (4975 VCCs).

Failing job: https://github.com/ahrav/Gossip-rs/actions/runs/22292874502/job/64483440356

## What Changed

Rewrote the Kani proof harness to use concrete symbolic values and a plain
array snapshot instead of a push-loop + `Vec::clone` pattern. This eliminates
the symbolic modeling of Vec's growth/allocation paths while preserving
identical verification coverage (all lengths 0..=4, arbitrary u32 values,
same assertions on len/repr/element values).

**Before (timed out):**
- Symbolic push loop pulling in Vec's grow_one/grow_amortized per iteration
- `vec.clone()` doubling allocation state
- Element-by-element verification loop

**After (tractable):**
- Concrete symbolic values in a `[u32; 4]` array
- `snapshot[..len].to_vec()` — single allocation, no growth path
- `assert_eq!(v.as_slice(), &snapshot[..len])` — single slice comparison

No production code changed — only a `#[cfg(kani)]` proof harness.

## Test Plan

- [x] `cargo test -p gossip-stdx` passes (7/7)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] Kani CI job completes within timeout (verify after merge)