### PR TITLE
Replace git subdirectory check with explicit root validation

### DIFF
--- a/crates/gossip-scanner-runtime/src/lib.rs
+++ b/crates/gossip-scanner-runtime/src/lib.rs
@@ -408,10 +408,12 @@ fn validate_git_repo_path(path: &Path) -> Result<PathBuf, ScanRuntimeError> {
         });
     }
 
+    // Use --show-toplevel to resolve the actual repository root rather than
+    // --is-inside-work-tree, which succeeds for arbitrary subdirectories.
     let output = Command::new("git")
         .arg("-C")
         .arg(path)
-        .args(["rev-parse", "--is-inside-work-tree"])
+        .args(["rev-parse", "--show-toplevel"])
         .output()
         .map_err(|error| ScanRuntimeError::Io {
             op: "git rev-parse",
@@ -426,11 +428,30 @@ fn validate_git_repo_path(path: &Path) -> Result<PathBuf, ScanRuntimeError> {
         });
     }
 
-    fs::canonicalize(path).map_err(|error| ScanRuntimeError::Io {
+    let toplevel = PathBuf::from(std::str::from_utf8(&output.stdout).unwrap_or("").trim_end());
+    let canonical_input = fs::canonicalize(path).map_err(|error| ScanRuntimeError::Io {
         op: "canonicalize",
         path: Some(path.to_path_buf()),
         error,
-    })
+    })?;
+    let canonical_toplevel = fs::canonicalize(&toplevel).map_err(|error| ScanRuntimeError::Io {
+        op: "canonicalize",
+        path: Some(toplevel.clone()),
+        error,
+    })?;
+
+    if canonical_input != canonical_toplevel {
+        return Err(ScanRuntimeError::InvalidPath {
+            source: "git",
+            path: path.to_path_buf(),
+            message: format!(
+                "path is inside a git repository but is not the repository root (root is '{}')",
+                canonical_toplevel.display()
+            ),
+        });
+    }
+
+    Ok(canonical_input)
 }
 
 fn available_workers() -> usize {

--- a/crates/gossip-scanner-runtime/src/lib_tests.rs
+++ b/crates/gossip-scanner-runtime/src/lib_tests.rs
@@ -204,3 +204,20 @@ fn scan_git_direct_errors_for_missing_repo() {
         ScanRuntimeError::InvalidPath { source: "git", .. }
     ));
 }
+
+#[test]
+fn scan_git_rejects_subdirectory_of_repo() {
+    let repo = create_test_repo(&[("sub/a.txt", b"password=alpha")]);
+    let subdir = repo.path().join("sub");
+    assert!(subdir.is_dir(), "subdirectory must exist");
+
+    // A subdirectory inside a git repo is not a repo root. Validation
+    // should reject it early rather than letting it through to a confusing
+    // runtime error from GitRepoPaths::resolve.
+    let result = scan_git_direct(&GitScanConfig::new(&subdir));
+    assert!(
+        result.is_err(),
+        "subdirectory of a repo should not be accepted as a git scan root; got {:?}",
+        result,
+    );
+}

--- a/crates/gossip-worker/src/main.rs
+++ b/crates/gossip-worker/src/main.rs
@@ -298,5 +298,9 @@ mod tests {
 
         let report = run_worker(&cfg).expect("git worker run");
         assert!(report.0 >= 1);
+        assert!(
+            report.2 >= 1,
+            "git scan should emit findings for test fixture"
+        );
     }
 }


### PR DESCRIPTION
Replace `--is-inside-work-tree` (which succeeds for any subdirectory within a repo)
with `--show-toplevel` (which returns the canonical repo root). Then validate that
the input path equals the repo root, rejecting subdirectories early.

Add test case to verify subdirectories are rejected before runtime resolution errors.